### PR TITLE
🚀 [STEP-14] coupon event

### DIFF
--- a/src/main/kotlin/kr/hhplus/be/server/application/couponevent/CouponEventApplication.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/couponevent/CouponEventApplication.kt
@@ -80,14 +80,14 @@ class CouponEventApplication(
     //     timeout = LockKeyConstants.EXTENDED_TIMEOUT
     // )
     fun issueCouponUser(criteria: CouponEventCriteria.IssueCoupon): CouponEventResult.IssueCoupon {
-         // 재고 감소 - 분산 락으로 동시성 제어
-        lockManager.executeWithDomainLock(
+        // 재고 감소 - 분산 락으로 동시성 제어
+        val updatedCouponEvent = lockManager.executeWithDomainLock(
             domainPrefix = LockKeyConstants.COUPON_EVENT_PREFIX,
             resourceType = LockKeyConstants.RESOURCE_ID,
             resourceId = criteria.couponEventId
         )  {
             transactionHelper.executeInTransaction {              
-                val updatedCouponEvent = couponEventService.decreaseStock(CouponEventCommand.Issue(criteria.couponEventId))
+                couponEventService.decreaseStock(CouponEventCommand.Issue(criteria.couponEventId))
             }
         }
         // 쿠폰 유저 생성

--- a/src/main/kotlin/kr/hhplus/be/server/application/couponevent/CouponEventApplication.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/application/couponevent/CouponEventApplication.kt
@@ -89,4 +89,6 @@ class CouponEventApplication(
             CouponEventResult.IssueCoupon.from(couponUser)
         }
     }
-} 
+
+    fun updateRdb(){ couponEventService.updateRdb() }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/couponevent/CouponEventController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/couponevent/CouponEventController.kt
@@ -50,4 +50,9 @@ class CouponEventController(
         val result = couponEventApplication.issueCouponUser(criteria)
         return BaseResponse.success(CouponEventResponse.IssueCoupon.from(result))
     }
+
+    override fun updateRdb(): BaseResponse<String>{
+        couponEventApplication.updateRdb()
+        return BaseResponse.success("")
+    }
 }

--- a/src/main/kotlin/kr/hhplus/be/server/controller/couponevent/CouponEventControllerApi.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/couponevent/CouponEventControllerApi.kt
@@ -105,4 +105,8 @@ interface CouponEventControllerApi {
         @Parameter(description = "쿠폰 발급 요청 정보", required = true)
         @RequestBody req: CouponEventRequest.IssueCoupon
     ): BaseResponse<CouponEventResponse.IssueCoupon>
+
+    @PutMapping("/coupon-events")
+    fun updateRdb(): BaseResponse<String>
+
 } 

--- a/src/main/kotlin/kr/hhplus/be/server/domain/couponevent/CouponEventRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/couponevent/CouponEventRepository.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository
 interface CouponEventRepository {
     fun create(couponEvent: CouponEvent): CouponEvent
     fun findById(id: String): CouponEvent?
-    fun findByIdWithLock(id: String): CouponEvent?
     fun findAll(): List<CouponEvent>
     fun save(couponEvent: CouponEvent): CouponEvent
+    fun updateRdb()
 }

--- a/src/main/kotlin/kr/hhplus/be/server/domain/couponevent/CouponEventService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/couponevent/CouponEventService.kt
@@ -64,4 +64,7 @@ class CouponEventService(
         // 리포지토리를 통해 업데이트
         return repository.save(updatedCouponEvent)
     }
+
+    @Transactional
+    fun updateRdb(){ repository.updateRdb() }
 } 

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/couponevent/CouponEventRedisConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/couponevent/CouponEventRedisConfig.kt
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.infrastructure.couponevent
+
+import kr.hhplus.be.server.infrastructure.config.RedisTemplateFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+
+@Configuration
+class CouponEventRedisConfig {
+    @Bean
+    fun couponEventRedisTemplate(redisConnectionFactory: RedisConnectionFactory): RedisTemplate<String, CouponEventRedisEntity> {
+        return RedisTemplateFactory.createRedisTemplate(redisConnectionFactory)
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/couponevent/CouponEventRedisEntity.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/couponevent/CouponEventRedisEntity.kt
@@ -1,0 +1,55 @@
+package kr.hhplus.be.server.infrastructure.couponevent
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import kr.hhplus.be.server.domain.couponevent.CouponEventBenefitMethod
+import kr.hhplus.be.server.domain.couponevent.CouponEvent
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+data class CouponEventRedisEntity(
+    val id: String,
+    val benefitMethod: CouponEventBenefitMethod,
+    val benefitAmount: String,
+    val totalIssueAmount: Long,
+    var leftIssueAmount: Long,
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+) {
+    /**
+     * 엔티티를 도메인 객체로 변환
+     */
+    fun toDomain(): CouponEvent {
+        return CouponEvent(
+            id = id,
+            benefitMethod = benefitMethod,
+            benefitAmount = benefitAmount,
+            totalIssueAmount = totalIssueAmount,
+            leftIssueAmount = leftIssueAmount,
+            createdAt = createdAt,
+            updatedAt = updatedAt
+        )
+    }
+
+    companion object {
+        /**
+         * 도메인 객체를 엔티티로 변환
+         */
+        fun fromDomain(domain: CouponEvent): CouponEventRedisEntity {
+            return CouponEventRedisEntity(
+                id = domain.id,
+                benefitMethod = domain.benefitMethod,
+                benefitAmount = domain.benefitAmount,
+                totalIssueAmount = domain.totalIssueAmount,
+                leftIssueAmount = domain.leftIssueAmount,
+                createdAt = domain.createdAt,
+                updatedAt = domain.updatedAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/couponevent/CouponEventRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/couponevent/CouponEventRepositoryImpl.kt
@@ -1,45 +1,65 @@
 package kr.hhplus.be.server.infrastructure.couponevent
 
+import jakarta.persistence.EntityManager
 import kr.hhplus.be.server.domain.couponevent.CouponEvent
 import kr.hhplus.be.server.domain.couponevent.CouponEventRepository
+import kr.hhplus.be.server.shared.lock.DistributedLockManager
+import kr.hhplus.be.server.shared.lock.LockKeyConstants
+import kr.hhplus.be.server.shared.lock.LockKeyGenerator
+import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
 import java.time.LocalDateTime
+import kotlin.reflect.jvm.internal.impl.descriptors.Visibilities.Private
 
 /**
  * CouponEventRepository 인터페이스의 JPA 구현체
  */
 @Repository
 class CouponEventRepositoryImpl(
-    private val couponEventJpaRepository: CouponEventJpaRepository
+    private val entityManager: EntityManager,
+    private val couponEventJpaRepository: CouponEventJpaRepository,
+    private val couponEventRedisTemplate: RedisTemplate<String, CouponEventRedisEntity>,
 ) : CouponEventRepository {
+
+    private val logger = LoggerFactory.getLogger(CouponEventRepositoryImpl::class.java)
+
+    // 키 접두사 상수
+    private val KEY_PREFIX = "orderItemRank"
+
+    private fun generateKey(id: String): String {
+        return "$KEY_PREFIX:id$id"
+    }
 
     /**
      * 쿠폰 이벤트를 생성
      */
-    @Transactional
     override fun create(couponEvent: CouponEvent): CouponEvent {
+        // Save in RDB
         val entity = CouponEventJpaEntity.fromDomain(couponEvent)
         val savedEntity = couponEventJpaRepository.save(entity)
+
+        // Save in Redis
+        val ops = couponEventRedisTemplate.opsForValue()
+        val key = generateKey(couponEvent.id)
+        val redisEntity = CouponEventRedisEntity.fromDomain(couponEvent)
+        ops.set(key, redisEntity)
+        couponEventRedisTemplate.expire(key, Duration.ofDays(365))
+
+        // Return
         return savedEntity.toDomain()
     }
 
     /**
      * 주어진 id의 쿠폰 이벤트를 조회
      */
-    @Transactional(readOnly = true)
     override fun findById(id: String): CouponEvent? {
-        val entity = couponEventJpaRepository.findById(id).orElse(null)
-        return entity?.toDomain()
-    }
-
-    /**
-     * 주어진 id의 쿠폰 이벤트를 비관적 락과 함께 조회
-     */
-    @Transactional
-    override fun findByIdWithLock(id: String): CouponEvent? {
-        val entity = couponEventJpaRepository.findByIdWithLock(id)
+        val key = generateKey(id)
+        val entity = couponEventRedisTemplate.opsForValue().get(key)
         return entity?.toDomain()
     }
 
@@ -55,10 +75,25 @@ class CouponEventRepositoryImpl(
     /**
      * 주어진 쿠폰 이벤트를 저장
      */
-    @Transactional
     override fun save(couponEvent: CouponEvent): CouponEvent {
-        val entity = CouponEventJpaEntity.fromDomain(couponEvent)
-        val savedEntity = couponEventJpaRepository.save(entity)
-        return savedEntity.toDomain()
+        val key = generateKey(couponEvent.id)
+        val redisEntity = CouponEventRedisEntity.fromDomain(couponEvent)
+        val ops = couponEventRedisTemplate.opsForValue()
+        ops.set(key, redisEntity)
+        return redisEntity.toDomain()
     }
-} 
+
+    @Scheduled(fixedRate = 1000 * 60 * 60)
+    @Transactional
+    override fun updateRdb(){
+        val ops = couponEventRedisTemplate.opsForValue()
+        val keys = couponEventRedisTemplate.keys("$KEY_PREFIX:*")
+        logger.info("updateRdb: keys = $keys")
+        val redisEntities = ops.multiGet(keys)!!
+        redisEntities
+            .map { it.toDomain() }
+            .map { CouponEventJpaEntity.fromDomain(it) }
+            .forEach { entityManager.merge(it) }
+    }
+
+}

--- a/src/test/kotlin/kr/hhplus/be/server/controllers/integration/CouponEventApiTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/controllers/integration/CouponEventApiTest.kt
@@ -280,7 +280,8 @@ class CouponEventApiTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").exists())
                 .andReturn()
-            
+
+
             // 생성된 이벤트 ID 추출
             val createEventResponse = createEventResult.response.contentAsString
             val eventResponseObj = objectMapper.readValue(createEventResponse, BaseResponse::class.java)
@@ -320,7 +321,13 @@ class CouponEventApiTest {
             val couponResponseObj = objectMapper.readValue(issueCouponResponse, BaseResponse::class.java)
             val couponData = couponResponseObj.data as Map<*, *>
             val newCouponUserId = couponData["couponUserId"] as String
-            
+
+            mockMvc.perform(
+                put("/api/v1/coupon-events")
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+
             // 4. 이벤트 목록 다시 조회하여 재고 감소 확인
             mockMvc.perform(
                 get("/api/v1/coupon-events")


### PR DESCRIPTION
<!-- 
## 🔗 관련 이슈
(필수) 해당 PR과 관련된 모든 이슈를 나열해주세요. 
- #이슈번호 (이슈 내용 요약)

Closes #이슈번호
-->
## 📝 PR 설명
<!-- (필수) 해당 PR이 왜 필요한지, 어떤 문제를 해결하는지, 어떤 기능을 추가했는지 명확하게 설명해주세요. -->

* 기존 RDB에 저장하던 쿠폰 이벤트 재고를 Redis로 이관했습니다.
* RDB에도 리스팅과 백업을 위해 동시에 저장하도록 만들었습니다.
* 락 범위를 줄여 부하를 줄였습니다.


## 📋 주요 변경사항
<!-- (필수) 코드 변경사항에 대해 설명해주세요. -->

## 🔍 리뷰 포인트
<!-- (선택) 리뷰어가 중점적으로 봐주었으면 하는 부분을 작성해주세요. --> 

* 재고차감과 쿠폰 발급 메소드를 분리하지는 않았으나,<br>어플리케이션 레이어에서 이벤트를 발급하고 수신하여 처리하는 방향을 고민했으나<br>(아마도 redis pub/sub)<br>추후 kafka 도입시 처리하려고 했습니다. 
 
